### PR TITLE
Improve/fix release script

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -64,11 +64,17 @@ else
   package="full-sdk"
 fi
 
-pushd "$sdk_path" || exit
+echo "Launching build script with following params:"
+echo "sdk_path = $sdk_path"
+echo "profile = $profile"
+echo "gradle_module = $gradle_module"
+echo "src-dir = $src_dir"
+
+pushd "$sdk_path" || exit 1
 
 cargo xtask kotlin build-android-library --profile "$profile" "${target_command[@]}" --src-dir "$src_dir" --package "$package"
 
-pushd "$scripts_dir/.." || exit
+pushd "$scripts_dir/.." || exit 1
 
 shift $((OPTIND - 1))
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -89,6 +89,17 @@ def get_git_hash(directory: str) -> str:
                             text=True)
     return result.stdout.strip()
 
+def get_tag_or_hash(directory: str, commit_hash):
+    result = subprocess.run(
+        ["git", "tag", "--points-at", commit_hash],
+        cwd=directory,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        return result.stdout.strip().split('\n')[0]  # Return the first tag, if multiple tags exist
+    else:
+        return commit_hash
 
 def commit_and_push_changes(directory: str, message: str):
     try:
@@ -234,11 +245,12 @@ execute_build_script(current_dir, sdk_path, args.module)
 override_version_in_build_version_file(build_version_file_path, args.version)
 
 sdk_commit_hash = get_git_hash(sdk_path)
-commit_message = f"Bump {args.module.name} version to {args.version} (matrix-rust-sdk {sdk_commit_hash})"
+sdk_tag_or_hash = get_tag_or_hash(sdk_commit_hash)
+commit_message = f"Bump {args.module.name} version to {args.version} (matrix-rust-sdk to {sdk_tag_or_hash})"
 commit_and_push_changes(project_root, commit_message)
 
 release_name = f"{args.module.name.lower()}-v{args.version}"
-release_notes = f"https://github.com/matrix-org/matrix-rust-sdk/tree/{sdk_commit_hash}"
+release_notes = f"https://github.com/matrix-org/matrix-rust-sdk/tree/{sdk_tag_or_hash}"
 asset_path = get_asset_path(project_root, args.module)
 asset_name = get_asset_name(args.module)
 


### PR DESCRIPTION
This PR should: 
- get properly the output of the build script while launching it in the release script
- add a way to check if a commit hash has an associated tag and prints it if any