### PR TITLE
Android: add coroutines dependency

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -4,12 +4,14 @@ object DependenciesVersions {
     const val jUnit = "4.12"
     const val nexusPublishGradlePlugin = "1.1.0"
     const val jna = "5.13.0"
+    const val coroutines = "1.7.1"
 }
 
 /**
  * To define dependencies
  */
 object Dependencies {
+    const val coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${DependenciesVersions.coroutines}"
     const val junit = "junit:junit:${DependenciesVersions.jUnit}"
     const val jna = "net.java.dev.jna:jna:${DependenciesVersions.jna}@aar"
 }

--- a/sdk/sdk-android/build.gradle
+++ b/sdk/sdk-android/build.gradle
@@ -45,5 +45,6 @@ android {
 
 dependencies {
     implementation Dependencies.jna
+    implementation Dependencies.coroutines
     testImplementation Dependencies.junit
 }


### PR DESCRIPTION
The SDK is now exposing async methods, so the generated bindings rely on coroutines.