### PR TITLE
Improve build times while building the SDK

### DIFF
--- a/.github/workflows/release_sdk.yml
+++ b/.github/workflows/release_sdk.yml
@@ -30,8 +30,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          save-if: true
-          cache-on-failure: true # necessary for the 1st build
+          save-if: ${{ github.ref == 'refs/head/main' || github.ref == 'main' }}
           workspaces: |
             ${{ env.TEMP_DIR }} -> target
 

--- a/.github/workflows/release_sdk.yml
+++ b/.github/workflows/release_sdk.yml
@@ -28,6 +28,12 @@ jobs:
       - name: Checkout this repo
         uses: actions/checkout@v3
 
+      - name: Checkout matrix rust sdk repo
+        uses: actions/checkout@v3
+        with:
+          repository: "matrix-org/matrix-rust-sdk"
+          ref: '${{ github.event.inputs.rust-checkout-ref }}'
+
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'main' }}
@@ -95,4 +101,4 @@ jobs:
           SONATYPE_STAGING_PROFILE_ID: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          python3 ./scripts/release.py --module SDK --version ${{ github.event.inputs.sdk-version }} --ref ${{ github.event.inputs.rust-checkout-ref }} --clone-to $RUST_SDK_PATH
+          python3 ./scripts/release.py --module SDK --version ${{ github.event.inputs.sdk-version }} --ref ${{ github.event.inputs.rust-checkout-ref }} --path-to-sdk $RUST_SDK_PATH --skip-clone

--- a/.github/workflows/release_sdk.yml
+++ b/.github/workflows/release_sdk.yml
@@ -34,6 +34,13 @@ jobs:
       - name: Create temp dir
         run: echo "TEMP_DIR=$(mktemp -d)" >> $GITHUB_ENV
 
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/head/main' }}
+          cache-on-failure: true # necessary for the 1st build
+          workspaces: |
+            ${{ env.TEMP_DIR }} -> target
+
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
@@ -48,13 +55,6 @@ jobs:
         id: install-ndk
         with:
           ndk-version: r25c
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/head/main' }}
-          cache-on-failure: true # necessary for the 1st build
-          workspaces: |
-            $TEMP_DIR -> target
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/release_sdk.yml
+++ b/.github/workflows/release_sdk.yml
@@ -40,6 +40,11 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
 
+      - name: Configure gradle
+        uses: gradle/gradle-build-action@v2.4.2
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'main' }}
+
       - name: Install android sdk
         uses: malinskiy/action-android/install-sdk@release/0.1.2
 

--- a/.github/workflows/release_sdk.yml
+++ b/.github/workflows/release_sdk.yml
@@ -20,19 +20,20 @@ jobs:
       group: ${{ github.ref }}-${{ github.job }}
       cancel-in-progress: true
 
+    env:
+      RUST_SDK_PATH: "./matrix-rust-sdk"
+
     steps:
 
       - name: Checkout this repo
         uses: actions/checkout@v3
 
-      - name: Create temp dir
-        run: echo "TEMP_DIR=$(mktemp -d)" >> $GITHUB_ENV
-
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'main' }}
+          cache-on-failure: true
           workspaces: |
-            ${{ env.TEMP_DIR }} -> target
+            ${{ env.RUST_SDK_PATH }} -> target
 
       - name: Set up JDK 11
         uses: actions/setup-java@v2
@@ -94,4 +95,4 @@ jobs:
           SONATYPE_STAGING_PROFILE_ID: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          python3 ./scripts/release.py --module SDK --version ${{ github.event.inputs.sdk-version }} --ref ${{ github.event.inputs.rust-checkout-ref }} --clone-to $TEMP_DIR
+          python3 ./scripts/release.py --module SDK --version ${{ github.event.inputs.sdk-version }} --ref ${{ github.event.inputs.rust-checkout-ref }} --clone-to $RUST_SDK_PATH

--- a/.github/workflows/release_sdk.yml
+++ b/.github/workflows/release_sdk.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          save-if: ${{ github.ref == 'refs/head/main' || github.ref == 'main' }}
+          save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'main' }}
           workspaces: |
             ${{ env.TEMP_DIR }} -> target
 

--- a/.github/workflows/release_sdk.yml
+++ b/.github/workflows/release_sdk.yml
@@ -3,10 +3,6 @@ name: Release SDK Library
 on:
   workflow_dispatch:
     inputs:
-      checkout-ref:
-        description: 'The branch, tag or SHA to checkout on this repo.'
-        required: true
-        default: 'main'
       rust-checkout-ref:
         description: 'The branch, tag or SHA to checkout on the rust sdk.'
         required: true
@@ -28,8 +24,6 @@ jobs:
 
       - name: Checkout this repo
         uses: actions/checkout@v3
-        with:
-          ref: main
 
       - name: Create temp dir
         run: echo "TEMP_DIR=$(mktemp -d)" >> $GITHUB_ENV

--- a/.github/workflows/release_sdk.yml
+++ b/.github/workflows/release_sdk.yml
@@ -32,7 +32,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: "matrix-org/matrix-rust-sdk"
-          ref: '${{ github.event.inputs.rust-checkout-ref }}'
+          ref: ${{ github.event.inputs.rust-checkout-ref }}
+          path: ${{ env.RUST_SDK_PATH }}
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -46,11 +47,6 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
-
-      - name: Configure gradle
-        uses: gradle/gradle-build-action@v2.4.2
-        with:
-          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'main' }}
 
       - name: Install android sdk
         uses: malinskiy/action-android/install-sdk@release/0.1.2

--- a/.github/workflows/release_sdk.yml
+++ b/.github/workflows/release_sdk.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          save-if: ${{ github.ref == 'refs/head/main' }}
+          save-if: true
           cache-on-failure: true # necessary for the 1st build
           workspaces: |
             ${{ env.TEMP_DIR }} -> target

--- a/.github/workflows/release_sdk.yml
+++ b/.github/workflows/release_sdk.yml
@@ -3,6 +3,10 @@ name: Release SDK Library
 on:
   workflow_dispatch:
     inputs:
+      checkout-ref:
+        description: 'The branch, tag or SHA to checkout on this repo.'
+        required: true
+        default: 'main'
       rust-checkout-ref:
         description: 'The branch, tag or SHA to checkout on the rust sdk.'
         required: true
@@ -10,7 +14,6 @@ on:
       sdk-version:
         description: 'The new version for the sdk library.'
         required: true
-
 
 jobs:
   build_native:
@@ -25,6 +28,11 @@ jobs:
 
       - name: Checkout this repo
         uses: actions/checkout@v3
+        with:
+          ref: main
+
+      - name: Create temp dir
+        run: echo "TEMP_DIR=$(mktemp -d)" >> $GITHUB_ENV
 
       - name: Set up JDK 11
         uses: actions/setup-java@v2
@@ -41,15 +49,12 @@ jobs:
         with:
           ndk-version: r25c
 
-      - uses: actions/cache@v2
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          save-if: ${{ github.ref == 'refs/head/main' }}
+          cache-on-failure: true # necessary for the 1st build
+          workspaces: |
+            $TEMP_DIR -> target
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@nightly
@@ -91,4 +96,4 @@ jobs:
           SONATYPE_STAGING_PROFILE_ID: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          python3 ./scripts/release.py --module SDK --version ${{ github.event.inputs.sdk-version }} --ref ${{ github.event.inputs.rust-checkout-ref }}
+          python3 ./scripts/release.py --module SDK --version ${{ github.event.inputs.sdk-version }} --ref ${{ github.event.inputs.rust-checkout-ref }} --clone-to $TEMP_DIR

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -8,7 +8,6 @@ import subprocess
 from enum import Enum, auto
 from tempfile import TemporaryDirectory
 
-
 class Module(Enum):
     SDK = auto()
     CRYPTO = auto()
@@ -226,12 +225,19 @@ parser.add_argument("-v", "--version", type=str, required=True,
                     help="Version as a string (e.g. '1.0.0')")
 parser.add_argument("-r", "--ref", type=str, required=True,
                     help="Ref to the git matrix-rust-sdk (branch name, commit or tag)")
+parser.add_argument("-c", "--clone-to", type=str, required=False,
+                    help="Choose a module (SDK or CRYPTO)")
 
 args = parser.parse_args()
 
 current_dir = os.path.dirname(os.path.abspath(__file__))
 project_root = os.path.dirname(current_dir).rstrip(os.sep)
 sdk_git_url = "https://github.com/matrix-org/matrix-rust-sdk.git"
+
+if args.clone_to:
+    sdk_path = args.clone_to
+else:
+    sdk_path = TemporaryDirectory().name
 
 print(f"Project Root Directory: {project_root}")
 print(f"Selected module: {args.module}")
@@ -248,10 +254,9 @@ else:
         f"The provided version ({args.version}) is not higher than the previous version ({major}.{minor}.{patch}) so bump the version before retrying.")
     exit(0)
 
-with TemporaryDirectory() as sdk_path:
-    clone_repo_and_checkout_ref(sdk_path, sdk_git_url, args.ref)
-    linkable_ref = get_linkable_ref(sdk_path, args.ref)
-    execute_build_script(current_dir, sdk_path, args.module)
+clone_repo_and_checkout_ref(sdk_path, sdk_git_url, args.ref)
+linkable_ref = get_linkable_ref(sdk_path, args.ref)
+execute_build_script(current_dir, sdk_path, args.module)
 
 override_version_in_build_version_file(build_version_file_path, args.version)
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -258,7 +258,7 @@ else:
         f"The provided version ({args.version}) is not higher than the previous version ({major}.{minor}.{patch}) so bump the version before retrying.")
     exit(0)
 
-if (!skip_clone):
+if skip_clone is False:
     clone_repo_and_checkout_ref(sdk_path, sdk_git_url, args.ref)
 
 linkable_ref = get_linkable_ref(sdk_path, args.ref)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -225,8 +225,10 @@ parser.add_argument("-v", "--version", type=str, required=True,
                     help="Version as a string (e.g. '1.0.0')")
 parser.add_argument("-r", "--ref", type=str, required=True,
                     help="Ref to the git matrix-rust-sdk (branch name, commit or tag)")
-parser.add_argument("-c", "--clone-to", type=str, required=False,
+parser.add_argument("-p", "--path-to-sdk", type=str, required=False,
                     help="Choose a module (SDK or CRYPTO)")
+parser.add_argument("-s", "--skip-clone", action="store_true", required=False,
+                    help="Skip cloning the Rust SDK repository")
 
 args = parser.parse_args()
 
@@ -234,10 +236,12 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 project_root = os.path.dirname(current_dir).rstrip(os.sep)
 sdk_git_url = "https://github.com/matrix-org/matrix-rust-sdk.git"
 
-if args.clone_to:
-    sdk_path = args.clone_to
+if args.path_to_sdk:
+    sdk_path = args.path_to_sdk
 else:
     sdk_path = TemporaryDirectory().name
+
+skip_clone = args.skip_clone
 
 print(f"Project Root Directory: {project_root}")
 print(f"Selected module: {args.module}")
@@ -254,7 +258,9 @@ else:
         f"The provided version ({args.version}) is not higher than the previous version ({major}.{minor}.{patch}) so bump the version before retrying.")
     exit(0)
 
-clone_repo_and_checkout_ref(sdk_path, sdk_git_url, args.ref)
+if (!skip_clone):
+    clone_repo_and_checkout_ref(sdk_path, sdk_git_url, args.ref)
+
 linkable_ref = get_linkable_ref(sdk_path, args.ref)
 execute_build_script(current_dir, sdk_path, args.module)
 


### PR DESCRIPTION
- This adds a Rust cache that should improve build times quite a bit.
- The cache is only saved when the release SDK workflow is run on `main`.
- It also adds some customization to the release script so we can skip cloning the SDK repo and set a custom path to it. That's necessary to get the cache working.