### PR TITLE
Move `RUST_SDK_PATH` to the parent dir 

### DIFF
--- a/.github/workflows/release_sdk.yml
+++ b/.github/workflows/release_sdk.yml
@@ -21,7 +21,7 @@ jobs:
       cancel-in-progress: true
 
     env:
-      RUST_SDK_PATH: "./matrix-rust-sdk"
+      RUST_SDK_PATH: "../matrix-rust-sdk"
 
     steps:
 


### PR DESCRIPTION
Make sure it's not included in `git add .` command later, which seems to be what broke pushing a new commit with the updated version to `main`.