### PR TITLE
Create parallelised SDK release workflow

### DIFF
--- a/.github/workflows/release_sdk_parallel.yml
+++ b/.github/workflows/release_sdk_parallel.yml
@@ -1,0 +1,171 @@
+name: Release SDK Library (parallel)
+
+on:
+  workflow_dispatch:
+    inputs:
+      rust-checkout-ref:
+        description: 'The branch, tag or SHA to checkout on the rust sdk.'
+        required: true
+        default: 'main'
+      sdk-version:
+        description: 'The new version for the sdk library.'
+        required: true
+
+jobs:
+  build_targets:
+    strategy:
+      matrix:
+#        target: [ "aarch64-linux-android", "armeabi-linux-android", "x86-linux-android", "x86_64-linux-android"]
+        target: [ "aarch64-linux-android" ]
+      fail-fast: true
+    name: "Build Rust target: ${{ matrix.target }}"
+    runs-on: ubuntu-latest
+
+    concurrency:
+      group: ${{ github.ref }}-${{ github.job }}-{{ matrix.target }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@v3
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'main' }}
+          cache-on-failure: true
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+
+      - name: Install android sdk
+        uses: malinskiy/action-android/install-sdk@release/0.1.2
+
+      - name: Install android ndk
+        uses: nttld/setup-ndk@v1
+        id: install-ndk
+        with:
+          ndk-version: r25c
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Add Rust targets
+        run: |
+          rustup target add x86_64-linux-android
+          rustup target add aarch64-linux-android
+          rustup target add armv7-linux-androideabi
+          rustup target add i686-linux-android
+
+      - name: Install cargo-ndk
+        continue-on-error: true
+        run: cargo install cargo-ndk
+
+      - name: Set up Python 3
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install argparse
+          pip install requests
+
+      - name: Run build script
+        run: |
+          python3 ./scripts/build-rust-for-target.py --module SDK --version ${{ github.event.inputs.sdk-version }} --ref ${{ github.event.inputs.rust-checkout-ref }} --target ${{ matrix.target }}
+
+      - name: Upload target artifacts
+        if: success() || failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: targets
+          if-no-files-found: error
+          path: ./sdk/sdk-android/src/main/jniLibs/*/libmatrix_sdk_ffi.so
+          retention-days: 1
+
+      - name: Upload FFI bindings
+        if: success() || failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: ffi-bindings
+          if-no-files-found: error
+          path: ./sdk/sdk-android/src/main/kotlin/
+          retention-days: 1
+
+  release_library:
+    name: "Release SDK Library"
+    needs: build_targets
+    runs-on: ubuntu-latest
+
+    concurrency:
+      group: ${{ github.ref }}-${{ github.job }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@v3
+
+      - name: Download target artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: targets
+          path: targets
+
+      - name: Copy artifacts to their right folders
+        run: |
+          pushd targets
+          cp -R . ../sdk/sdk-android/src/main/jniLibs/
+          popd
+
+      - name: Download FFI bindings
+        uses: actions/download-artifact@v3
+        with:
+          name: ffi-bindings
+          path: ffi-bindings
+
+      - name: Copy FFI bindings to their package
+        run: |
+          pushd ffi-bindings
+          cp -R . ../sdk/sdk-android/src/main/kotlin/
+          popd
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+
+      - name: Install android sdk
+        uses: malinskiy/action-android/install-sdk@release/0.1.2
+
+      - name: Set up Python 3
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install argparse
+          pip install requests
+
+      - name: Run release script
+        env:
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+          SONATYPE_STAGING_PROFILE_ID: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}
+          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 ./scripts/release_sdk.py --module SDK --version ${{ github.event.inputs.sdk-version }}

--- a/.github/workflows/release_sdk_parallel.yml
+++ b/.github/workflows/release_sdk_parallel.yml
@@ -15,8 +15,7 @@ jobs:
   build_targets:
     strategy:
       matrix:
-#        target: [ "aarch64-linux-android", "armeabi-linux-android", "x86-linux-android", "x86_64-linux-android"]
-        target: [ "aarch64-linux-android" ]
+        target: [ "aarch64-linux-android", "armeabi-linux-android", "x86-linux-android", "x86_64-linux-android"]
       fail-fast: true
     name: "Build Rust target: ${{ matrix.target }}"
     runs-on: ubuntu-latest

--- a/scripts/build-aar.sh
+++ b/scripts/build-aar.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -e
+
+is_release='false'
+gradle_module='sdk'
+output=''
+
+helpFunction() {
+  echo ""
+  echo "Usage: $0 -r -m sdk"
+  echo -e "\t-o Optional output path with the expected name of the aar file"
+  echo -e "\t-r Flag to build in release mode"
+  echo -e "\t-m Option to select the gradle module to build. Default is sdk"
+  exit 1
+}
+
+while getopts ':r:m:o:' 'opt'; do
+  case ${opt} in
+  'r') is_release='true' ;;
+  'm') gradle_module="$OPTARG" ;;
+  'o') output="$OPTARG" ;;
+  ?) helpFunction ;;
+  esac
+done
+
+moveFunction() {
+  if [ -z "$output" ]; then
+    echo "No output path provided, keep the generated path"
+  else
+    mv "$1" "$output"
+  fi
+}
+
+pushd ../
+
+## For now, cargo ndk includes all generated so files from the target directory, so makes sure it just includes the one we need.
+echo "Clean .so files"
+if [ "$gradle_module" = "crypto" ]; then
+  find crypto/crypto-android/src/main/jniLibs -type f ! -name 'libmatrix_sdk_crypto_ffi.so' -delete
+else
+  find sdk/sdk-android/src/main/jniLibs -type f ! -name 'libmatrix_sdk_ffi.so' -delete
+fi
+
+if ${is_release}; then
+  if [ "$gradle_module" = "sdk" ]; then
+    ./gradlew :sdk:sdk-android:assembleRelease
+    moveFunction "sdk/sdk-android/build/outputs/aar/sdk-android-release.aar"
+  else
+    ./gradlew :crypto:crypto-android:assembleRelease
+    moveFunction "crypto/crypto-android/build/outputs/aar/crypto-android-release.aar"
+  fi
+else
+  if [ "$gradle_module" = "sdk" ]; then
+    ./gradlew :sdk:sdk-android:assembleDebug
+    moveFunction "sdk/sdk-android/build/outputs/aar/sdk-android-debug.aar"
+  else
+    ./gradlew :crypto:crypto-android:assembleDebug
+    moveFunction "crypto/crypto-android/build/outputs/aar/crypto-android-debug.aar"
+  fi
+fi
+
+popd

--- a/scripts/build-rust-for-target.py
+++ b/scripts/build-rust-for-target.py
@@ -1,0 +1,140 @@
+#!/usr/bin/python3
+
+import argparse
+import os
+import re
+import subprocess
+from enum import Enum, auto
+from tempfile import TemporaryDirectory
+
+class Module(Enum):
+    SDK = auto()
+    CRYPTO = auto()
+
+def module_type(value):
+    try:
+        return Module[value.upper()]
+    except KeyError:
+        raise argparse.ArgumentTypeError(
+            f"Invalid module choice: {value}. Available options: SDK, CRYPTO")
+
+
+def get_build_version_file_path(module: Module, project_root: str) -> str:
+    if module == Module.SDK:
+        return os.path.join(project_root, 'buildSrc/src/main/kotlin', 'BuildVersionsSDK.kt')
+    elif module == Module.CRYPTO:
+        return os.path.join(project_root, 'buildSrc/src/main/kotlin', 'BuildVersionsCrypto.kt')
+    else:
+        raise ValueError(f"Unknown module: {module}")
+
+
+def read_version_numbers_from_kotlin_file(file_path):
+    with open(file_path, "r") as file:
+        content = file.read()
+
+    major_version = int(re.search(r"majorVersion\s*=\s*(\d+)", content).group(1))
+    minor_version = int(re.search(r"minorVersion\s*=\s*(\d+)", content).group(1))
+    patch_version = int(re.search(r"patchVersion\s*=\s*(\d+)", content).group(1))
+
+    return major_version, minor_version, patch_version
+
+
+def clone_repo_and_checkout_ref(directory, git_url, ref):
+    # Clone the repo
+    subprocess.run(
+        ["git", "clone", git_url, directory],
+        check=True,
+        text=True,
+    )
+    # Checkout the specified ref (commit hash, tag, or branch)
+    subprocess.run(
+        ["git", "checkout", ref],
+        cwd=directory,
+        check=True,
+        text=True,
+    )
+
+def get_linkable_ref(directory, ref):
+    result = subprocess.run(
+        ["git", "show-ref", "--verify", f"refs/heads/{ref}"],
+        cwd=directory,
+        capture_output=True,
+        text=True
+    )
+    if result.returncode == 0:
+        # The reference is a valid branch name, return the corresponding commit hash
+        return result.stdout.strip().split()[0]
+
+    # The reference is not a valid branch name, return the reference itself
+    return ref
+
+
+def is_provided_version_higher(major: int, minor: int, patch: int, provided_version: str) -> bool:
+    provided_major, provided_minor, provided_patch = map(int, provided_version.split('.'))
+    if provided_major > major:
+        return True
+    elif provided_major == major:
+        if provided_minor > minor:
+            return True
+        elif provided_minor == minor:
+            return provided_patch > patch
+    return False
+
+
+def execute_build_script(script_directory: str, sdk_path: str, module: Module, target: str):
+    print("Execute build script...")
+    build_script_path = os.path.join(script_directory, "build-rust-for-target.sh")
+    subprocess.run(
+        ["/bin/bash", build_script_path, "-p", sdk_path, "-m", module.name.lower(), "-t", target, "-r"],
+        check=True,
+        text=True
+    )
+    print("Finish executing build script with success")
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-m", "--module", type=module_type, required=True,
+                    help="Choose a module (SDK or CRYPTO)")
+parser.add_argument("-v", "--version", type=str, required=True,
+                    help="Version as a string (e.g. '1.0.0')")
+parser.add_argument("-t", "--target", type=str, required=True,
+                    help="Choose a target ('arm64-v8a', 'armv7a', 'x86', 'x86_64')")
+parser.add_argument("-r", "--ref", type=str, required=True,
+                    help="Ref to the git matrix-rust-sdk (branch name, commit or tag)")
+parser.add_argument("-p", "--path-to-sdk", type=str, required=False,
+                    help="Choose a module (SDK or CRYPTO)")
+parser.add_argument("-s", "--skip-clone", action="store_true", required=False,
+                    help="Skip cloning the Rust SDK repository")
+
+args = parser.parse_args()
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+project_root = os.path.dirname(current_dir).rstrip(os.sep)
+sdk_git_url = "https://github.com/matrix-org/matrix-rust-sdk.git"
+
+if args.path_to_sdk:
+    sdk_path = args.path_to_sdk
+else:
+    sdk_path = TemporaryDirectory().name
+
+skip_clone = args.skip_clone
+
+print(f"Project Root Directory: {project_root}")
+print(f"Selected module: {args.module}")
+print(f"Version: {args.version}")
+print(f"SDK git ref: {args.ref}")
+
+build_version_file_path = get_build_version_file_path(args.module, project_root)
+major, minor, patch = read_version_numbers_from_kotlin_file(build_version_file_path)
+if is_provided_version_higher(major, minor, patch, args.version):
+    print(
+        f"The provided version ({args.version}) is higher than the previous version ({major}.{minor}.{patch}) so we can start the release process")
+else:
+    print(
+        f"The provided version ({args.version}) is not higher than the previous version ({major}.{minor}.{patch}) so bump the version before retrying.")
+    exit(0)
+
+if skip_clone is False:
+    clone_repo_and_checkout_ref(sdk_path, sdk_git_url, args.ref)
+
+linkable_ref = get_linkable_ref(sdk_path, args.ref)
+execute_build_script(current_dir, sdk_path, args.module, args.target)

--- a/scripts/build-rust-for-target.sh
+++ b/scripts/build-rust-for-target.sh
@@ -40,6 +40,8 @@ fi
 
 if [ -z "$only_target" ]; then
   helpFunction
+else
+  target_command=("--only-target" "$only_target")
 fi
 
 if [ "$gradle_module" = "crypto" ]; then

--- a/scripts/build-rust-for-target.sh
+++ b/scripts/build-rust-for-target.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -e
+
+helpFunction() {
+  echo ""
+  echo "Usage: $0 -r -p /Documents/dev/matrix-rust-sdk -m sdk"
+  echo -e "\t-p Local path to the rust-sdk repository"
+  echo -e "\t-o Optional output path with the expected name of the aar file"
+  echo -e "\t-r Flag to build in release mode"
+  echo -e "\t-m Option to select the gradle module to build. Default is sdk"
+  echo -e "\t-t Option to to select an android target to build against."
+  exit 1
+}
+
+scripts_dir=$(
+  cd "$(dirname "${BASH_SOURCE[0]}")" || exit
+  pwd -P
+)
+
+is_release='false'
+gradle_module='sdk'
+only_target=''
+output=''
+
+while getopts ':rp:m:t:o:' 'opt'; do
+  case ${opt} in
+  'r') is_release='true' ;;
+  'p') sdk_path="$OPTARG" ;;
+  'm') gradle_module="$OPTARG" ;;
+  't') only_target='arm64-v8a' ;;
+  'o') output="$OPTARG" ;;
+  ?) helpFunction ;;
+  esac
+done
+
+if [ -z "$sdk_path" ]; then
+  echo "sdk_path is empty, please provide one"
+  helpFunction
+fi
+
+if [ -z "$only_target" ]; then
+  helpFunction
+fi
+
+if [ "$gradle_module" = "crypto" ]; then
+  ## NDK is needed for https://crates.io/crates/olm-sys
+  if [ -z "$ANDROID_NDK" ]; then
+    echo "please set the ANDROID_NDK environment variable to your Android NDK installation"
+    exit 1
+  fi
+  src_dir="$scripts_dir/../crypto/crypto-android/src/main"
+  package="crypto-sdk"
+else
+  src_dir="$scripts_dir/../sdk/sdk-android/src/main"
+  package="full-sdk"
+fi
+
+if ${is_release}; then
+  profile="release"
+else
+  profile="reldbg"
+fi
+
+echo "Launching build script with following params:"
+echo "sdk_path = $sdk_path"
+echo "profile = $profile"
+echo "gradle_module = $gradle_module"
+echo "src-dir = $src_dir"
+
+pushd "$sdk_path" || exit 1
+
+cargo xtask kotlin build-android-library --profile "$profile" "${target_command[@]}" --src-dir "$src_dir" --package "$package"
+
+pushd "$scripts_dir/.." || exit 1
+
+shift $((OPTIND - 1))
+
+moveFunction() {
+  if [ -z "$output" ]; then
+    echo "No output path provided, keep the generated path"
+  else
+    mv "$1" "$output"
+  fi
+}
+
+## For now, cargo ndk includes all generated so files from the target directory, so makes sure it just includes the one we need.
+echo "Clean .so files"
+if [ "$gradle_module" = "crypto" ]; then
+  find crypto/crypto-android/src/main/jniLibs -type f ! -name 'libmatrix_sdk_crypto_ffi.so' -delete
+else
+  find sdk/sdk-android/src/main/jniLibs -type f ! -name 'libmatrix_sdk_ffi.so' -delete
+fi

--- a/scripts/release_sdk.py
+++ b/scripts/release_sdk.py
@@ -1,0 +1,180 @@
+#!/usr/bin/python3
+
+import argparse
+import os
+import re
+import requests
+import subprocess
+from enum import Enum, auto
+from tempfile import TemporaryDirectory
+
+class Module(Enum):
+    SDK = auto()
+    CRYPTO = auto()
+
+def override_version_in_build_version_file(file_path: str, new_version: str):
+    with open(file_path, 'r') as file:
+        content = file.read()
+
+    new_major, new_minor, new_patch = map(int, new_version.split('.'))
+
+    content = re.sub(r"(majorVersion\s*=\s*)(\d+)", rf"\g<1>{new_major}", content)
+    content = re.sub(r"(minorVersion\s*=\s*)(\d+)", rf"\g<1>{new_minor}", content)
+    content = re.sub(r"(patchVersion\s*=\s*)(\d+)", rf"\g<1>{new_patch}", content)
+
+    with open(file_path, 'w') as file:
+        file.write(content)
+
+def commit_and_push_changes(directory: str, message: str):
+    try:
+        subprocess.run(["git", "add", "."], cwd=directory, check=True)
+        subprocess.run(["git", "commit", "-m", message], cwd=directory, check=True)
+        subprocess.run(["git", "push"], cwd=directory, check=True)
+        print("Changes committed and pushed successfully.")
+    except subprocess.CalledProcessError as e:
+        print("Failed to commit and push changes.")
+        print("Error message:")
+        print(e.stderr)
+
+def upload_asset_to_github_release(upload_url: str, asset_path: str, asset_name: str):
+    print(f"Uploading {asset_name} to github release..")
+    # Build headers with token and content type
+    headers = {
+        "Authorization": f"token {github_token}",
+        "Content-Type": "application/octet-stream"
+    }
+
+    # Read asset file as binary content
+    with open(asset_path, "rb") as asset_file:
+        asset_content = asset_file.read()
+
+    # Set the filename in the request URL
+    upload_url = upload_url.replace("{?name,label}", f"?name={asset_name}")
+
+    # Send asset upload request
+    response = requests.post(upload_url, headers=headers, data=asset_content)
+    if response.status_code == 201:
+        print(f"Asset '{asset_name}' uploaded successfully.")
+    else:
+        print("Failed to upload asset.")
+        print("Response:")
+        print(response.json())
+        exit(1)
+
+def create_github_release(repo_url: str, tag_name: str, release_name: str, release_notes: str):
+    print(f"Create github release {tag_name}")
+    # Build release payload
+    payload = {
+        "tag_name": tag_name,
+        "name": release_name,
+        "body": release_notes,
+        "draft": False,
+        "prerelease": False
+    }
+
+    # Build request headers
+    headers = {
+        "Authorization": f"token {github_token}",
+        "Accept": "application/vnd.github.v3+json"
+    }
+
+    # Send release request
+    response = requests.post(f"{repo_url}/releases", headers=headers, json=payload)
+    if response.status_code == 201:
+        print("Release created successfully.")
+        release_data = response.json()
+        upload_url = release_data["upload_url"]
+        upload_asset_to_github_release(upload_url, asset_path, asset_name)
+    else:
+        print("Failed to create release.")
+        print("Response:")
+        print(response.json())
+        exit(1)
+
+def get_asset_name(module: Module) -> str:
+    if module == Module.SDK:
+        return "matrix-android-sdk.aar"
+    elif module == Module.CRYPTO:
+        return "matrix-android-crypto.aar"
+    else:
+        raise ValueError(f"Unknown module: {module}")
+
+
+def get_asset_path(root_project_dir: str, module: Module) -> str:
+    if module == Module.SDK:
+        return os.path.join(root_project_dir, "sdk/sdk-android/build/outputs/aar",
+                            "sdk-android-release.aar")
+    elif module == Module.CRYPTO:
+        return os.path.join(root_project_dir, "crypto/crypto-android/build/outputs/aar",
+                            "crypto-android-release.aar")
+    else:
+        raise ValueError(f"Unknown module: {module}")
+
+def get_publish_task(module: Module) -> str:
+    if module == Module.SDK:
+        return ":sdk:sdk-android:publishToSonatype"
+    elif module == Module.CRYPTO:
+        return ":crypto:crypto-android:publishToSonatype"
+    else:
+        raise ValueError(f"Unknown module: {module}")
+
+
+def run_publish_close_and_release_tasks(root_project_dir, publish_task: str):
+    gradle_command = f"./gradlew {publish_task} closeAndReleaseStagingRepository"
+    result = subprocess.run(gradle_command, shell=True, cwd=root_project_dir, text=True)
+    if result.returncode != 0:
+        raise Exception(f"Gradle tasks failed with return code {result.returncode}")
+
+def build_aar_files(script_directory: str, module: Module):
+    print("Execute build script...")
+    build_script_path = os.path.join(script_directory, "build-aar.sh")
+    subprocess.run(
+        ["/bin/bash", build_script_path, "-m", module.name.lower(), "-r"],
+        check=True,
+        text=True
+    )
+    print("Finish executing build script with success")
+
+
+github_token = os.environ['GITHUB_API_TOKEN']
+if github_token is None:
+    print("Please set GITHUB_API_TOKEN environment variable")
+    exit(1)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-m", "--module", type=module_type, required=True,
+                    help="Choose a module (SDK or CRYPTO)")
+parser.add_argument("-v", "--version", type=str, required=True,
+                    help="Version as a string (e.g. '1.0.0')")
+
+args = parser.parse_args()
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+project_root = os.path.dirname(current_dir).rstrip(os.sep)
+
+print(f"Project Root Directory: {project_root}")
+print(f"Selected module: {args.module}")
+print(f"Version: {args.version}")
+
+build_version_file_path = get_build_version_file_path(args.module, project_root)
+major, minor, patch = read_version_numbers_from_kotlin_file(build_version_file_path)
+
+build_aar_files(current_dir, args.module)
+
+override_version_in_build_version_file(build_version_file_path, args.version)
+
+commit_message = f"Bump {args.module.name} version to {args.version} (matrix-rust-sdk to {linkable_ref})"
+commit_and_push_changes(project_root, commit_message)
+
+release_name = f"{args.module.name.lower()}-v{args.version}"
+release_notes = f"https://github.com/matrix-org/matrix-rust-sdk/tree/{linkable_ref}"
+asset_path = get_asset_path(project_root, args.module)
+asset_name = get_asset_name(args.module)
+
+create_github_release("https://api.github.com/repos/matrix-org/matrix-rust-components-kotlin",
+                      release_name, release_name, release_notes)
+
+run_publish_close_and_release_tasks(
+    project_root,
+    get_publish_task(args.module),
+)


### PR DESCRIPTION
This should allow us to parallelise the work done for releasing a new Rust SDK version.

However, I couldn't fully test it locally and I won't be able to test it in the repo until the new workflow is in `main`.