### PR TITLE
Fix parallelised release flow

### DIFF
--- a/.github/workflows/release_sdk_parallel.yml
+++ b/.github/workflows/release_sdk_parallel.yml
@@ -15,13 +15,14 @@ jobs:
   build_targets:
     strategy:
       matrix:
-        target: [ "aarch64-linux-android", "armeabi-linux-android", "x86-linux-android", "x86_64-linux-android"]
-      fail-fast: true
+        target: [ "aarch64-linux-android", "armv7-linux-androideabi", "i686-linux-android", "x86_64-linux-android" ]
     name: "Build Rust target: ${{ matrix.target }}"
     runs-on: ubuntu-latest
+    outputs:
+      linkable_ref: ${{ steps.set_linkable_ref.outputs.linkable_ref }}
 
     concurrency:
-      group: ${{ github.ref }}-${{ github.job }}-{{ matrix.target }}
+      group: ${{ github.ref }}-${{ github.job }}-${{ matrix.target }}
       cancel-in-progress: true
 
     steps:
@@ -81,6 +82,13 @@ jobs:
       - name: Run build script
         run: |
           python3 ./scripts/build-rust-for-target.py --module SDK --version ${{ github.event.inputs.sdk-version }} --ref ${{ github.event.inputs.rust-checkout-ref }} --target ${{ matrix.target }}
+
+      - name: Set linkable git ref
+        id: set_linkable_ref
+        run: |
+          pushd ${{ env.RUST_SDK_PATH }}
+          echo linkable_ref=$(git show-ref --verify refs/heads/${{ github.event.inputs.rust-checkout-ref }} | awk '{print $1}') >> $GITHUB_OUTPUT
+          popd
 
       - name: Upload target artifacts
         if: success() || failure()
@@ -167,4 +175,13 @@ jobs:
           SONATYPE_STAGING_PROFILE_ID: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          python3 ./scripts/release_sdk.py --module SDK --version ${{ github.event.inputs.sdk-version }}
+          python3 ./scripts/release_sdk.py --module SDK --version ${{ github.event.inputs.sdk-version }} --linkable-ref ${{ needs.build_targets.outputs.linkable_ref }}
+
+      - name: Upload AAR results
+        if: success() || failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: results
+          if-no-files-found: error
+          path: ./sdk/sdk-android/build/**/*.aar
+          retention-days: 1

--- a/scripts/build-aar.sh
+++ b/scripts/build-aar.sh
@@ -14,7 +14,7 @@ helpFunction() {
   exit 1
 }
 
-while getopts ':r:m:o:' 'opt'; do
+while getopts ':rm:o:' 'opt'; do
   case ${opt} in
   'r') is_release='true' ;;
   'm') gradle_module="$OPTARG" ;;
@@ -30,8 +30,6 @@ moveFunction() {
     mv "$1" "$output"
   fi
 }
-
-pushd ../
 
 ## For now, cargo ndk includes all generated so files from the target directory, so makes sure it just includes the one we need.
 echo "Clean .so files"
@@ -58,5 +56,3 @@ else
     moveFunction "crypto/crypto-android/build/outputs/aar/crypto-android-debug.aar"
   fi
 fi
-
-popd

--- a/scripts/build-rust-for-target.sh
+++ b/scripts/build-rust-for-target.sh
@@ -27,7 +27,7 @@ while getopts ':rp:m:t:o:' 'opt'; do
   'r') is_release='true' ;;
   'p') sdk_path="$OPTARG" ;;
   'm') gradle_module="$OPTARG" ;;
-  't') only_target='arm64-v8a' ;;
+  't') only_target="$OPTARG" ;;
   'o') output="$OPTARG" ;;
   ?) helpFunction ;;
   esac


### PR DESCRIPTION
Adds the fixes needed to make the parallelised release flow work properly. A successful run can be found [here](https://github.com/matrix-org/matrix-rust-components-kotlin/actions/runs/6900783246), although it didn't actually publish any versions (the final steps for pushing commits, creating the release and releasing the version in maven were disabled).

Build times are lower by an order of magnitude (🎉) and I tested the generated AAR files locally and it worked fine.