### PR TITLE
Try fixing linkable ref for commit hashes

### DIFF
--- a/.github/workflows/release_sdk_parallel.yml
+++ b/.github/workflows/release_sdk_parallel.yml
@@ -87,7 +87,13 @@ jobs:
         id: set_linkable_ref
         run: |
           pushd ${{ env.RUST_SDK_PATH }}
-          echo linkable_ref=$(git show-ref --verify refs/heads/${{ github.event.inputs.rust-checkout-ref }} | awk '{print $1}') >> $GITHUB_OUTPUT
+          if COMMIT_HASH=$(git show-ref --verify refs/heads/${{ github.event.inputs.rust-checkout-ref }} | awk '{print $1}'); then
+            echo linkable_ref=$COMMIT_HASH >> $GITHUB_OUTPUT
+            echo "Using commit hash $COMMIT_HASH"
+          else
+            echo linkable_ref=${{ github.event.inputs.rust-checkout-ref }} >> $GITHUB_OUTPUT
+            echo "Using commit hash ${{ github.event.inputs.rust-checkout-ref }}"
+          fi
           popd
 
       - name: Upload target artifacts


### PR DESCRIPTION
This tries to get a valid commit hash from the provided ref, and if it can't it assumes the ref *is* the commit hash. It should allow us to use commit hashes for SDK versions instead of a branch/tag.