### PR TITLE
Fix parallel build failure

### DIFF
--- a/.github/workflows/release_crypto.yml
+++ b/.github/workflows/release_crypto.yml
@@ -49,7 +49,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Install android sdk
-        uses: malinskiy/action-android/install-sdk@release/0.1.2
+        uses: malinskiy/action-android/install-sdk@release/0.1.4
         
       - name: Install android ndk   
         uses: nttld/setup-ndk@v1

--- a/.github/workflows/release_sdk.yml
+++ b/.github/workflows/release_sdk.yml
@@ -49,7 +49,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Install android sdk
-        uses: malinskiy/action-android/install-sdk@release/0.1.2
+        uses: malinskiy/action-android/install-sdk@release/0.1.4
 
       - name: Install android ndk
         uses: nttld/setup-ndk@v1

--- a/.github/workflows/release_sdk_parallel.yml
+++ b/.github/workflows/release_sdk_parallel.yml
@@ -41,7 +41,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Install android sdk
-        uses: malinskiy/action-android/install-sdk@release/0.1.2
+        uses: malinskiy/action-android/install-sdk@release/0.1.4
 
       - name: Install android ndk
         uses: nttld/setup-ndk@v1
@@ -158,7 +158,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Install android sdk
-        uses: malinskiy/action-android/install-sdk@release/0.1.2
+        uses: malinskiy/action-android/install-sdk@release/0.1.4
 
       - name: Set up Python 3
         uses: actions/setup-python@v5

--- a/.github/workflows/release_sdk_parallel.yml
+++ b/.github/workflows/release_sdk_parallel.yml
@@ -100,7 +100,7 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
-          name: targets
+          name: targets-${{ matrix.target }}
           if-no-files-found: error
           path: ./sdk/sdk-android/src/main/jniLibs/*/libmatrix_sdk_ffi.so
           retention-days: 1
@@ -112,6 +112,7 @@ jobs:
           name: ffi-bindings
           if-no-files-found: error
           path: ./sdk/sdk-android/src/main/kotlin/
+          overwrite: true
           retention-days: 1
 
   release_library:
@@ -131,6 +132,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: targets
+          pattern: targets-*
+          merge-multiple: true
           path: targets
 
       - name: Copy artifacts to their right folders

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -31,7 +31,7 @@ jobs:
           ref: '${{ github.event.inputs.rust-checkout-ref }}'
     
       - name: Install android sdk
-        uses: malinskiy/action-android/install-sdk@release/0.1.2
+        uses: malinskiy/action-android/install-sdk@release/0.1.4
         
       - name: Install android ndk   
         uses: nttld/setup-ndk@v1


### PR DESCRIPTION
First commit is an upgrade (not sure why Renovate did not take it)

Second comit:
[Fix uploading artifact failure.](https://github.com/matrix-org/matrix-rust-components-kotlin/commit/5c126768c7fe803ae6ec4d7bb3c307faeef55ee5)

Failure was: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
at https://github.com/matrix-org/matrix-rust-components-kotlin/actions/runs/7583622946.
`actions/upload-artifact@v4` generates immutable artifact (new since v3).
Update the flow according to https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md