### PR TITLE
Pin the Rust nightly version

### DIFF
--- a/.github/workflows/release_sdk_parallel.yml
+++ b/.github/workflows/release_sdk_parallel.yml
@@ -55,7 +55,7 @@ jobs:
           ndk-version: r25c
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@nightly-2024-02-06
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v1


### PR DESCRIPTION
It now should match the one used in the matrix-rust-sdk repo: https://github.com/matrix-org/matrix-rust-sdk/pull/3103