### PR TITLE
Allow releasing snapshot versions of the Rust SDK

### DIFF
--- a/buildSrc/src/main/kotlin/BuildVersionsSDK.kt
+++ b/buildSrc/src/main/kotlin/BuildVersionsSDK.kt
@@ -1,5 +1,5 @@
 object BuildVersionsSDK {
-	const val majorVersion = 0
-	const val minorVersion = 2
-	const val patchVersion = 17
+	const val majorVersion = "0"
+	const val minorVersion = "2"
+	const val patchVersion = "17"
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -2,7 +2,7 @@ object DependenciesVersions {
     const val androidGradlePlugin = "8.2.2"
     const val kotlin = "1.9.22"
     const val jUnit = "4.13.2"
-    const val nexusPublishGradlePlugin = "1.3.0"
+    const val nexusPublishGradlePlugin = "2.0.0"
     const val jna = "5.14.0"
     const val coroutines = "1.7.3"
     const val annotations = "1.7.1"

--- a/scripts/build-rust-for-target.py
+++ b/scripts/build-rust-for-target.py
@@ -32,9 +32,9 @@ def read_version_numbers_from_kotlin_file(file_path):
     with open(file_path, "r") as file:
         content = file.read()
 
-    major_version = int(re.search(r"majorVersion\s*=\s*(\d+)", content).group(1))
-    minor_version = int(re.search(r"minorVersion\s*=\s*(\d+)", content).group(1))
-    patch_version = int(re.search(r"patchVersion\s*=\s*(\d+)", content).group(1))
+    major_version = re.search(r"majorVersion\s*=\s*\"(.+)\"", content).group(1)
+    minor_version = re.search(r"minorVersion\s*=\s*\"(.+)\"", content).group(1)
+    patch_version = re.search(r"patchVersion\s*=\s*\"(.+)\"", content).group(1)
 
     return major_version, minor_version, patch_version
 
@@ -110,13 +110,16 @@ print(f"SDK git ref: {args.ref}")
 
 build_version_file_path = get_build_version_file_path(args.module, project_root)
 major, minor, patch = read_version_numbers_from_kotlin_file(build_version_file_path)
-if is_provided_version_higher(major, minor, patch, args.version):
-    print(
-        f"The provided version ({args.version}) is higher than the previous version ({major}.{minor}.{patch}) so we can start the release process")
-else:
-    print(
-        f"The provided version ({args.version}) is not higher than the previous version ({major}.{minor}.{patch}) so bump the version before retrying.")
-    exit(0)
+is_snapshot_version = args.version.endswith("-SNAPSHOT")
+
+if not is_snapshot_version:
+    if is_provided_version_higher(major, minor, patch, args.version):
+        print(
+            f"The provided version ({args.version}) is higher than the previous version ({major}.{minor}.{patch}) so we can start the release process")
+    else:
+        print(
+            f"The provided version ({args.version}) is not higher than the previous version ({major}.{minor}.{patch}) so bump the version before retrying.")
+        exit(0)
 
 if skip_clone is False:
     clone_repo_and_checkout_ref(sdk_path, sdk_git_url, args.ref)

--- a/scripts/publish-module.gradle
+++ b/scripts/publish-module.gradle
@@ -53,4 +53,5 @@ signing {
             rootProject.ext["signing.password"],
     )
     sign publishing.publications
+    required { !PUBLISH_VERSION.endsWith("-SNAPSHOT") }
 }

--- a/scripts/publish-root.gradle
+++ b/scripts/publish-root.gradle
@@ -31,4 +31,7 @@ nexusPublishing {
             snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
         }
     }
+    useStaging.convention(project.provider {
+        !project.hasProperty("snapshot")
+    })
 }


### PR DESCRIPTION
This allows us to upload snapshot versions of the library, for SDK versions that should be uploaded so others can build the clients and test it, but shouldn't be considered official releases.