### PR TITLE
fix change from checkout@v3 to v4?

### DIFF
--- a/.github/workflows/release_crypto.yml
+++ b/.github/workflows/release_crypto.yml
@@ -32,8 +32,6 @@ jobs:
 
       - name: Checkout this repo
         uses: actions/checkout@v4
-        with:
-          path: main
 
       - name: Configure git user
         run: |


### PR DESCRIPTION
Getting an error when running the crypto release scipt. 
```
##[group]Run git config user.name github-actions
fatal: not in a git directory
```

The last succesfull build (6 mo old) was using `actions/checkout@v3`
Trying to update to match the sdk release action