### PR TITLE
Fix crypto sdk release script

### DIFF
--- a/.github/workflows/release_crypto.yml
+++ b/.github/workflows/release_crypto.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   build_native:
     name: Build and generate crypto native libs
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     env:
       OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
       OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -60,10 +60,10 @@ jobs:
         with:
           ndk-version: r25c
 
-      - name: Create symlinks for buildchain
-        run: |
-          export PATH="${{ steps.install-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/darwin-x86_64/bin:$PATH"
-          echo $PATH
+      # - name: Create symlinks for buildchain
+      #   run: |
+      #     export PATH="${{ steps.install-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/darwin-x86_64/bin:$PATH"
+      #     echo $PATH
 
       - uses: actions/cache@v4
         with:
@@ -111,7 +111,7 @@ jobs:
       - name: Run build script
         env:
           ANDROID_NDK: ${{ steps.install-ndk.outputs.ndk-path }}
-        run: ./main/scripts/build.sh -r -m crypto -p rust-sdk
+        run: ./scripts/build.sh -r -m crypto -p rust-sdk
 
       - name: Find all .aar files
         run: find . -name "*.aar"
@@ -132,7 +132,7 @@ jobs:
           CRYPTO_SDK_VERSION: ${{ github.event.inputs.crypto-sdk-version }}
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          python3 ./main/scripts/release_crypto.py --version ${{ github.event.inputs.crypto-sdk-version }} --sdk_path ./rust-sdk
+          python3 ./scripts/release_crypto.py --version ${{ github.event.inputs.crypto-sdk-version }} --sdk_path ./rust-sdk
 
 #      - name: Run test python
 #        run: |

--- a/scripts/release_crypto.py
+++ b/scripts/release_crypto.py
@@ -63,7 +63,8 @@ def get_git_hash(directory: str) -> str:
 
 def commit_and_push_changes(directory: str, message: str):
     try:
-        subprocess.run(["git", "add", "."], cwd=directory, check=True)
+        subprocess.run(["git", "add", "buildSrc/src/main/kotlin/BuildVersionsCrypto.kt"], cwd=directory, check=True)
+        subprocess.run(["git", "add", "crypto/crypto-android/src/main/kotlin/org/matrix/rustcomponents/sdk/crypto/matrix_sdk_crypto_ffi.ktt"], cwd=directory, check=True)
         subprocess.run(["git", "commit", "-m", message], cwd=directory, check=True)
         subprocess.run(["git", "push"], cwd=directory, check=True)
         print("Changes committed and pushed successfully.")

--- a/scripts/release_crypto.py
+++ b/scripts/release_crypto.py
@@ -64,7 +64,7 @@ def get_git_hash(directory: str) -> str:
 def commit_and_push_changes(directory: str, message: str):
     try:
         subprocess.run(["git", "add", "buildSrc/src/main/kotlin/BuildVersionsCrypto.kt"], cwd=directory, check=True)
-        subprocess.run(["git", "add", "crypto/crypto-android/src/main/kotlin/org/matrix/rustcomponents/sdk/crypto/matrix_sdk_crypto_ffi.ktt"], cwd=directory, check=True)
+        subprocess.run(["git", "add", "crypto/crypto-android/src/main/kotlin/org/matrix/rustcomponents/sdk/crypto/matrix_sdk_crypto_ffi.kt"], cwd=directory, check=True)
         subprocess.run(["git", "commit", "-m", message], cwd=directory, check=True)
         subprocess.run(["git", "push"], cwd=directory, check=True)
         print("Changes committed and pushed successfully.")


### PR DESCRIPTION
script path is now `./script` and not `./main/script`
Also had to change from `macos-latest` to `ubuntu-latest`, with macos it was failing with a linker error:
```
 note: ld.lld: error: unable to find library -lclang_rt.builtins-x86_64-android
```

The `release_crypto.py` script is also updated to only commit the required file. If unchanged given that we checkout now in the current folder, it will add a `rust-sdk` submodule