### PR TITLE
Fix Crypto SDK build

### DIFF
--- a/buildSrc/src/main/kotlin/BuildVersionsCrypto.kt
+++ b/buildSrc/src/main/kotlin/BuildVersionsCrypto.kt
@@ -1,5 +1,5 @@
 object BuildVersionsCrypto {
-	const val majorVersion = 26
-	const val minorVersion = 1
-	const val patchVersion = 28
+	const val majorVersion = "26"
+	const val minorVersion = "1"
+	const val patchVersion = "28"
 }

--- a/crypto/crypto-android/build.gradle
+++ b/crypto/crypto-android/build.gradle
@@ -45,5 +45,6 @@ android {
 
 dependencies {
     implementation Dependencies.jna
+    implementation Dependencies.annotations
     testImplementation Dependencies.junit
 }


### PR DESCRIPTION
Fix building the crypto SDK. This was needed to successfully run https://github.com/matrix-org/matrix-rust-components-kotlin/actions/runs/25731081108/job/75576560313, although the flow says it failed because of some maven issue, the version was published correctly.