### PR TITLE
Use `small-release-stripped` for release builds instead of `dist`

### DIFF
--- a/.github/workflows/release_sdk_parallel.yml
+++ b/.github/workflows/release_sdk_parallel.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Extract debug symbols
         run: |
-          pushd ${RUST_SDK_PATH}/target/${{ matrix.target }}/dist
+          pushd ${RUST_SDK_PATH}/target/${{ matrix.target }}/small-release-stripped
           echo "Original library with debug info:"
           ls -lh libmatrix_sdk_ffi.so 
           echo "Extracting debug symbols"
@@ -129,10 +129,10 @@ jobs:
           popd
           echo "Replacing built file with stripped one"
           EXISTING_FILE=$(find sdk/sdk-android/src/main/jniLibs/ -name libmatrix_sdk_ffi.so)
-          cp ${RUST_SDK_PATH}/target/${{ matrix.target }}/dist/libmatrix_sdk_ffi.so $EXISTING_FILE
+          cp ${RUST_SDK_PATH}/target/${{ matrix.target }}/small-release-stripped/libmatrix_sdk_ffi.so $EXISTING_FILE
           ls -lh $EXISTING_FILE
           mkdir -p debuginfo/${{ matrix.target }}
-          cp ${RUST_SDK_PATH}/target/${{ matrix.target }}/dist/libmatrix_sdk_ffi.so.debug debuginfo/${{ matrix.target }}/
+          cp ${RUST_SDK_PATH}/target/${{ matrix.target }}/small-release-stripped/libmatrix_sdk_ffi.so.debug debuginfo/${{ matrix.target }}/
 
       - name: Set linkable git ref
         id: set_linkable_ref

--- a/scripts/build-rust-for-target.sh
+++ b/scripts/build-rust-for-target.sh
@@ -58,7 +58,7 @@ else
 fi
 
 if ${is_release}; then
-  profile="dist"
+  profile="small-release-stripped"
 else
   profile="reldev"
 fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -65,7 +65,7 @@ else
 fi
 
 if ${is_release}; then
-  profile="dist"
+  profile="small-release-stripped"
 else
   profile="reldev"
 fi


### PR DESCRIPTION
It behaves the same, `dist` was just renamed in https://github.com/matrix-org/matrix-rust-sdk/pull/6755.